### PR TITLE
Responsive hash anchors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,13 @@ content="http://powerboat.robysoft.net/images/pb88-3.jpg" />
 	  		</nav>
 	  	</header>
 	  	<div class = "main-content">
-		  	<div class = "section about" name = "about">
+		  	<div class = "section about">
+		  		<a name="about"></a>
 		  		<h1>About</h1>
 		  		<p>The Death By Audio Arcade is a series of local multiplayer arcade cabinets produced by NYC-based indie game developers at the legendary music venue, Death by Audio, in Brooklyn, NY.</p>
 		  	</div>	
-		  	<div class = "section" name = "featuring">
+		  	<div class = "section">
+		  		<a name="featuring"></a>
 		  		<h1>Now Featuring...</h1>
 		  		<div class = "slideshow-container">
 			  		<div class="cycle-slideshow" 
@@ -85,7 +87,8 @@ content="http://powerboat.robysoft.net/images/pb88-3.jpg" />
 					</div>
 				</div>
 		  	</div>	
-		  	<div class = "section" name="upcoming">
+		  	<div class = "section">
+		  		<a name="upcoming"></a>
 		  		<h1>Upcoming Games + Events</h1>
 		  		<div class = "left-section">
 
@@ -112,7 +115,8 @@ content="http://powerboat.robysoft.net/images/pb88-3.jpg" />
 
 		  	
 		  	</div>	
-		  	<div class = "section" name="previous">
+		  	<div class = "section">
+		  		<a name="previous"></a>
 		  		<h1>The Games</h1>
 		  		<div class = "game field-1">	
 		  			<img src="images/gifs/f1-sm.gif" width="75">
@@ -157,7 +161,8 @@ content="http://powerboat.robysoft.net/images/pb88-3.jpg" />
 
 		  		</div>	
 		  	</div>
-		  	<div class = "section gallery" name="gallery">
+		  	<div class = "section gallery">
+		  		<a name="gallery"></a>
 		  		<h1>Gallery</h1>
 		  		<div class = "row image-gallery">
 
@@ -262,7 +267,8 @@ content="http://powerboat.robysoft.net/images/pb88-3.jpg" />
                         </div>
 
 		  	</div>
-		  	<div class = "section press" name="press">
+		  	<div class = "section press">
+		  		<a name="press"></a>
 		  		<h1>Press + Links</h1>
 		  		<ul>
 		  			<li><a href = "https://hackaday.com/2015/10/06/arcades-dont-call-it-a-comeback/#more-172729">Arcades: Don't Call it a Comeback</a></li>


### PR DESCRIPTION
Direct links to hash anchors should cause the browser to scroll the viewport to that section. For example, linking directly to "http://deathbyaudioarcade.com/#featuring". Currently, the hash anchors are only followed when they are clicked on. This change also allows the headings to work when Javascript is disabled.